### PR TITLE
FIX[build-apk.sh] change rm to mv

### DIFF
--- a/build-apk.sh
+++ b/build-apk.sh
@@ -2,4 +2,4 @@
 ./gradlew test
 ./gradlew assembleDebug
 mkdir -p build/apk
-rm app/build/outputs/apk/debug/app-debug.apk build/apk/test.apk
+mv app/build/outputs/apk/debug/app-debug.apk build/apk/test.apk


### PR DESCRIPTION
tu as fais une erreur dans le script (le log de travis me l'a indiqué). lorsque l'APK est crée, tu le supprimé au lieu de le déplacer :
RM = remove
MV = move
Je propose ce patch pour corriger ce problème proprement.
P.S je vais checker l'intégration de la fastlane ce soir si je peux trouver un moyen, désolé, je n'ai pas trop pu être dispo avant